### PR TITLE
Fix English mistyped release month

### DIFF
--- a/news.php.en
+++ b/news.php.en
@@ -13,7 +13,7 @@
 </h3>
 <p>
 	The current stable version is
-	<strong>Release 26</strong> of July 20 2020,
+	<strong>Release 26</strong> of June 20 2020,
 	please refer to the <a href="download.php.en">Download</a>
 	options.
 </p>


### PR DESCRIPTION
Release 26 was available on June 20, not July 20.